### PR TITLE
Improve CSV delimiter detection in printer search

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,8 @@ async function loadData(){
     Papa.parse(CSV_URL,{download:true,header:true,delimiter:delim,dynamicTyping:false,skipEmptyLines:true,
       complete:r=>resolve(r.data),error:reject});
   });
-  let data=await parse(';'); if (!data || data.length<1) data=await parse(',');
+  let data=await parse(';');
+  if (!data || data.length<1 || Object.keys(data[0]||{}).length<2) data=await parse(',');
   return data;
 }
 function populateBrands(rows){


### PR DESCRIPTION
## Summary
- handle CSV delimiter fallback by checking column count before switching to comma

## Testing
- `node test_load.js`


------
https://chatgpt.com/codex/tasks/task_e_689afd86cd54832c874cb62607b950e1